### PR TITLE
restricted zooming out too far on map

### DIFF
--- a/app/javascript/plugins/init_mapbox.js
+++ b/app/javascript/plugins/init_mapbox.js
@@ -23,7 +23,9 @@ const initMapbox = () => {
     mapboxgl.accessToken = indexMapElement.dataset.mapboxApiKey;
     const map = new mapboxgl.Map({
       container: 'index_map',
-      style: 'mapbox://styles/bgordon/ckhzzm3wt20m419mv7cs8k3lb'
+      style: 'mapbox://styles/bgordon/ckhzzm3wt20m419mv7cs8k3lb',
+      minZoom: 14,
+
     });
     const businessMarkers = JSON.parse(indexMapElement.dataset.markers);
     businessMarkers.forEach((marker) => {


### PR DESCRIPTION
restricted zooming out too far on map:
- this was done to discourage zooming out to a city-scale and to focus the user's attention on their "mile"