### PR TITLE
Added placeholder in search bar to encourage searching for Berlin

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -17,7 +17,7 @@
             <div class="searchbar">
               <%= text_field_tag :query,
                   params[:query],
-                  placeholder: "Enter your home address"
+                  placeholder: 'Enter your home address or try "Berlin"'
                 %>
                 <%= submit_tag "Explore", class: "button_search" %>
             </div>


### PR DESCRIPTION
A quick "fix" until I implement the "No businesses in your area" functionality. 
- Added "Try "Berlin" to the placeholder text so that non-logged in members are encouraged to search for Berlin, where they will see businesses and a functioning map. 