### PR TITLE
event partial name corrected

### DIFF
--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -57,7 +57,7 @@
           <% if @events %>
             <div class="events">
               <% @events.each do |event| %>
-                  <%= render partial: 'events/event_card', locals: { event: event } %>
+                  <%= render partial: 'events/_event', locals: { event: event } %>
                   <br>
               <% end %>
             </div>


### PR DESCRIPTION
smaill fix to prevent crash on bookmark page - partial was rendered with incorrect name