### PR TITLE
Email confirmation

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -1,0 +1,7 @@
+class ConfirmationsController < Devise::ConfirmationsController
+  private
+  def after_confirmation_path_for(resource_name, resource)
+    sign_in(resource) # In case you want to sign in the user
+    root_path
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,10 +18,5 @@ class User < ApplicationRecord
   after_validation :geocode, if: :will_save_change_to_address?
 
   has_one_attached :avatar
-
-  protected
   
-  def confirmation_required?
-    false
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable, :validatable, :confirmable
 
   geocoded_by :address
   after_validation :geocode, if: :will_save_change_to_address?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,4 +18,10 @@ class User < ApplicationRecord
   after_validation :geocode, if: :will_save_change_to_address?
 
   has_one_attached :avatar
+
+  protected
+  
+  def confirmation_required?
+    false
+  end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,5 +1,7 @@
 Rails.application.configure do
   config.action_mailer.default_url_options = { host: "http://localhost:3000" }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {:address => "localhost", :port => 1025}
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded on

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,7 +1,8 @@
 Rails.application.configure do
   config.action_mailer.default_url_options = { host: "http://localhost:3000" }
   config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = {:address => "localhost", :port => 1025}
+  config.action_mailer.smtp_settings = { :address => '127.0.0.1', :port => 1025 }
+  config.action_mailer.perform_deliveries = true
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded on

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,9 +1,11 @@
 Rails.application.configure do
-  config.action_mailer.default_url_options = { host: "http://localhost:3000" }
-  config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = { :address => '127.0.0.1', :port => 1025 }
-  config.action_mailer.perform_deliveries = true
   # Settings specified here will take precedence over those in config/application.rb.
+
+    config.action_mailer.default_url_options = { host: "http://localhost:3000" }
+    config.action_mailer.delivery_method = :smtp
+    config.action_mailer.smtp_settings = { :address => '127.0.0.1', :port => 1025 }
+    # Whether an email was sent or not can be tested by having mailcatcher open (http://127.0.0.1:1080/) when sign-up is completed
+    config.action_mailer.perform_deliveries = true
 
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -3,7 +3,7 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
   :address => "127.0.0.1",
-  :port    => 25,
+  :port    => "25",
   :domain  => "http://www.innermile.org"
 }
   # Settings specified here will take precedence over those in config/application.rb.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,5 +1,11 @@
 Rails.application.configure do
   config.action_mailer.default_url_options = { host: "http://www.innermile.org" }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+  :address => "127.0.0.1",
+  :port    => 25,
+  :domain  => "http://www.innermile.org"
+}
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -5,6 +5,9 @@
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
+  config.action_mailer.default_url_options = { host: "http://localhost:3000" }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {:address => "localhost", :port => 1025}
 
   config.cache_classes = false
   config.action_view.cache_template_loading = true

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -157,7 +157,7 @@ Devise.setup do |config|
   # initial account confirmation) to be applied. Requires additional unconfirmed_email
   # db field (see migrations). Until confirmed, new email is stored in
   # unconfirmed_email column, and copied to email column on successful confirmation.
-  config.reconfirmable = true
+  config.reconfirmable = false
 
   # Defines which key will be used when confirming an account
   # config.confirmation_keys = [:email]

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -143,7 +143,7 @@ Devise.setup do |config|
   # without confirming their account.
   # Default is 0.days, meaning the user cannot access the website without
   # confirming their account.
-  # config.allow_unconfirmed_access_for = 2.days
+  config.allow_unconfirmed_access_for = nil
 
   # A period that the user is allowed to confirm their account before their
   # token becomes invalid. For example, if set to 3.days, the user can confirm

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
 
   get 'conversations/show'
-  devise_for :users
+  devise_for :users, controllers: { confirmations: 'confirmations' }
   root to: 'pages#home'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 

--- a/db/migrate/20201219121237_add_confirmable_to_devise.rb
+++ b/db/migrate/20201219121237_add_confirmable_to_devise.rb
@@ -1,0 +1,20 @@
+class AddConfirmableToDevise < ActiveRecord::Migration[6.0]
+  def up
+    add_column :users, :confirmation_token, :string
+    add_column :users, :confirmed_at, :datetime
+    add_column :users, :confirmation_sent_at, :datetime
+    # add_column :users, :unconfirmed_email, :string # Only if using reconfirmable
+    add_index :users, :confirmation_token, unique: true
+    # User.reset_column_information # Need for some types of updates, but not for update_all.
+    # To avoid a short time window between running the migration and updating all existing
+    # users as confirmed, do the following
+    User.update_all confirmed_at: DateTime.now
+    # All existing user accounts should be able to log in after this.
+  end
+
+  def down
+    remove_index :users, :confirmation_token
+    remove_columns :users, :confirmation_token, :confirmed_at, :confirmation_sent_at
+    # remove_columns :users, :unconfirmed_email # Only if using reconfirmable
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_10_135931) do
+ActiveRecord::Schema.define(version: 2020_12_19_121237) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -148,6 +148,10 @@ ActiveRecord::Schema.define(version: 2020_12_10_135931) do
     t.boolean "business_owner"
     t.float "latitude"
     t.float "longitude"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
Email confirmation when user signs-up. Not required to access features within the app as we do not have a 3rd party service for that - email can be checked using mailcatcher - route provided within environment/development under config.action_mailer

- User model updated for devise :confirmable action
- Controller added for Confirmations - will be used for actions within email sent out
- Routes updated to support the above controller
- Various configs updated
- Schema updated to support Model changes
- As always, styling is minimal